### PR TITLE
Fix ordering issue in PostgreSQL

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "5432:5432"
     environment:
+      - LC_COLLATE=C
+      - LC_CTYPE=C
       - POSTGRES_DB=mystockdb
       - POSTGRES_USER=mystock
       - POSTGRES_PASSWORD=c10neC0ding1nZozz

--- a/backend/mystock/market/views.py
+++ b/backend/mystock/market/views.py
@@ -1,3 +1,4 @@
+from django.db.models.functions import Collate
 from django.shortcuts import render
 from drf_spectacular.utils import extend_schema
 from mystock.market.models import Stock
@@ -17,7 +18,7 @@ class StockViewSet(viewsets.ReadOnlyModelViewSet):
     )
     @action(detail=False)
     def increasing(self, request):
-        stocks = Stock.objects.all().order_by("-kr_name")
+        stocks = Stock.objects.all().order_by(Collate("kr_name", "C").desc())
 
         page = self.paginate_queryset(stocks)
         if page is not None:
@@ -33,7 +34,7 @@ class StockViewSet(viewsets.ReadOnlyModelViewSet):
     )
     @action(detail=False)
     def decreasing(self, request):
-        stocks = Stock.objects.all().order_by("kr_name")
+        stocks = Stock.objects.all().order_by(Collate("kr_name", "C"))
 
         page = self.paginate_queryset(stocks)
         if page is not None:


### PR DESCRIPTION
홈 화면에 필요한 API를 정의하는 과정(8ceba37)에서, (아직 주가 필드가 없기 때문에) 임의로 정렬 기준을 국문 주식명으로 정했다가 발견한 이슈.
postgres의 기본 정렬을 사용하는 경우, 한국어[^1] 값이 포함된 필드를 정렬하면 사전식 순서가 아닌 뭔가 이상한 순서로 정렬된 결과를 얻는다. (여러 번 호출해도 결과가 같은 것으로 보아, 무작위 정렬은 아니고 뭔가 기준이 있는 것 같은데, 원하는 결과는 사전식 순서이므로 더 자세히 살펴보지 않는다.)

근본적인 해결 방법은 데이터베이스 생성 **전**(또는 postgres 설치 전)에 `LC_COLLATE`와 `LC_CTYPE`[^2]의 값을 `C`로 설정하는 것이다.
이미 생성된 데이터베이스에 대해 `LC_COLLATE`와 `LC_CTYPE` 값을 변경하는 방법은 없는 것으로 보이며, 다음 두 가지 방법 중 하나로 이슈를 해결할 수 있다.

1. 모든 데이터를 백업한 후 기존 데이터베이스를 drop하고, `LC_COLLATE` 값을 설정한 데이터베이스를 생성해서 백업한 데이터를 가져온다.
2. [정렬이 필요한 쿼리에서 필드 단위로 COLLATE를 지정한다.](https://docs.djangoproject.com/en/3.2/ref/models/database-functions/#collate)

[^1]: 아마 한국어 뿐만 아니라 CJK에서 비슷하게 발생하는 이슈가 아닐까 추측함.
[^2]: 이 이슈로 검색해서 찾아본 게시물들은 `LC_COLLATE` 설정만으로 이슈를 해결했다고 작성되어있어서 굳이 필요하지 않을 것 같긴 하지만, [공식 문서](https://www.postgresql.org/docs/current/collation.html)에 '기본 데이터 정렬은 데이터베이스 생성 시 지정된 `LC_COLLATE`와 `LC_CTYPE` 값을 선택한다'는 내용이 있어서 둘 다 수정하기로 함.